### PR TITLE
Fix missing payment amount parameter

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -54,6 +54,23 @@ app.post('/api/create-payment-intent', async (req, res) => {
   try {
     const { amount, currency, subscription_type, price_id, customer_id, subscription_id } = req.body;
 
+    // Validate required parameters
+    if (amount === undefined || amount === null) {
+      serverLogger.error('Missing amount parameter in payment intent request', { body: req.body });
+      return res.status(400).json({
+        success: false,
+        error: 'Missing required parameter: amount'
+      });
+    }
+    
+    if (typeof amount !== 'number' || isNaN(amount)) {
+      serverLogger.error('Invalid amount parameter in payment intent request', { amount, body: req.body });
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid amount parameter'
+      });
+    }
+
     // For trial subscriptions (amount = 0), use Setup Intent instead of Payment Intent
     if (amount === 0) {
       const setupIntent = await stripe.setupIntents.create({


### PR DESCRIPTION
Add robust client-side and server-side validation for the payment intent `amount` parameter.

The original error "Missing required param: amount" from Stripe indicated the `amount` field was not being sent at all, likely due to a subtle client-side timing or configuration access issue where `pricing.amount` was `undefined` during request construction. This PR adds defensive checks and validation on both client and server to guarantee the `amount` parameter is always present and valid, preventing such scenarios.

## Summary by Sourcery

Add defensive client- and server-side validation to ensure the Stripe payment intent amount parameter is always present, valid, and properly logged, and improve error handling for debugging.

Bug Fixes:
- Prevent missing required amount parameter errors by validating and defaulting the payment amount before creating the payment intent

Enhancements:
- Add client-side guards to verify subscription type and pricing configuration before request construction
- Normalize and validate amount value, defaulting to zero if undefined or invalid
- Consolidate request payload into a single object and add development-only logging of request details
- Improve fetch error handling to include response text in thrown errors
- Add server-side validation and logging for missing or non-numeric amount parameters with appropriate 400 responses