### PR TITLE
Update server payment default amount

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -154,7 +154,7 @@ class CheckoutApp {
 
     // Update pricing details
     const monthlyAmount = isAnnual ? 14700 / 12 : 14700; // $147.00 in cents
-    const annualAmount = isAnnual ? 147000 : 14700 * 12; // $1,470.00 in cents
+    const annualAmount = isAnnual ? 14700 : 14700; // $147.00 in cents
     
     this.elements['subtotal'].textContent = this.formatCurrency(monthlyAmount);
     this.elements['total-after-trial'].textContent = this.formatCurrency(monthlyAmount);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -356,7 +356,7 @@ app.get('*', (req, res) => {
         },
         annual: {
           priceId: process.env.ANNUAL_PRICE_ID || '',
-          amount: parseInt(process.env.ANNUAL_AMOUNT || '147000'),
+          amount: parseInt(process.env.ANNUAL_AMOUNT || '14700'),
           currency: 'usd',
           interval: 'year',
           hasTrial: false,


### PR DESCRIPTION
Update default annual subscription amount to 14700 cents ($147.00).

## Summary by Sourcery

Set the default annual subscription amount to 14700 cents ($147) and adjust both server and client code to reflect the updated pricing.

Bug Fixes:
- Correct default annual subscription amount to 14700 cents on the server fallback
- Update client-side checkout logic to use the new annual price of 14700 cents